### PR TITLE
Adición de la lista de opciones para parciales u ordinarios en la captura de calificaciones

### DIFF
--- a/reportes/captura_cal.php
+++ b/reportes/captura_cal.php
@@ -144,12 +144,12 @@ $facultad = $db->query($fac);
         }
 
         .container {
-            max-width: 1500px;
+            max-width: 1000px;
             margin: 50px auto;
             padding: 20px;
             background-color: #fff;
             border-radius: 8px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
         }
 
         h1 {
@@ -175,40 +175,42 @@ $facultad = $db->query($fac);
         }
 
         .grades-table {
-            width: 100%;
+            width: auto; /* Ajusta el ancho al contenido */
+            margin: 0 auto; /* Centra la tabla */
             border-collapse: collapse;
             margin-top: 30px;
+            text-align: center;
         }
 
         .grades-table th, .grades-table td {
-            border: 5px solid #ccc;
-            padding: 5px;
-            text-align: left;
+            border: 1px solid #d3d3d3;
+            padding: 10px;
+            font-size: 14px;
+            white-space: nowrap; /* Evita que el contenido se envuelva */
         }
 
+        .grades-table th {
+            background-color: #f0f0f0;
+            font-weight: bold;
+            color: #333;
+        }
 
-		.grades-table th:nth-child(1), .grades-table td:nth-child(1) {
-    		width: 2%;
-		}
+        .grades-table td {
+            background-color: #ffffff;
+        }
 
-		.grades-table th:nth-child(2), .grades-table td:nth-child(2) {
-   			 width: 6%; 
-		}
+        .grades-table td:focus, .grades-table td input:focus {
+            outline: 2px solid #4a90e2; /* Resalta la celda activa */
+            background-color: #e8f0fe; /* Color de fondo al hacer foco */
+        }
 
-		.grades-table th:nth-child(3), .grades-table td:nth-child(3) {
-   		 width: 20%; 
-		}
-	
-		.grades-table th:nth-child(4), .grades-table td:nth-child(4),
-		.grades-table th:nth-child(5), .grades-table td:nth-child(5),
-		.grades-table th:nth-child(6), .grades-table td:nth-child(6) {
-  		  width: 5%; /* Ancho para las columnas de parciales */
-		}
+            /* Ajusta el ancho del campo de entrada de las calificaciones */
+        .grades-table td input[type="text"] {
+            width: 60px; /* Ajusta el ancho a un tamaño compacto */
+            text-align: center; /* Centra el texto en el campo */
+        }
 
-		.grades-table th {
-  		  background-color: #f4f4f4;
-		}
-
+        /* Estilo para el botón */
         button {
             display: block;
             width: 100%;
@@ -219,12 +221,15 @@ $facultad = $db->query($fac);
             border-radius: 4px;
             cursor: pointer;
             transition: background-color 0.3s;
+            margin-top: 20px; /* Espacio adicional arriba del botón */
         }
 
         button:hover {
             background-color: #0056b3;
         }
     </style>
+
+
     <script>
     // Función para cargar materias basadas en el grupo seleccionado
     function cargarMaterias() {
@@ -255,6 +260,57 @@ $facultad = $db->query($fac);
         // Enviar la solicitud con el grupo seleccionado y un indicador AJAX
         xhr.send("grupo=" + grupoSeleccionado + "&ajax=true");
     }
+
+    document.addEventListener('DOMContentLoaded', function() {
+    const inputs = Array.from(document.querySelectorAll('tbody input[type="text"]'));
+
+        // Calcula el número de columnas de forma dinámica basado en la primera fila
+        const firstRowInputs = document.querySelectorAll('tbody tr:first-child input[type="text"]');
+        const columns = firstRowInputs.length;
+
+        document.addEventListener('keydown', function(e) {
+            const focused = document.activeElement;
+
+            // Verifica si el elemento enfocado es un input y si es editable
+            if (focused.tagName.toLowerCase() === 'input' && focused.type === 'text') {
+                const index = inputs.indexOf(focused);
+                let newIndex = index;
+
+                // Obtiene la posición del cursor en el campo actual
+                const cursorPos = focused.selectionStart;
+                const valueLength = focused.value.length;
+
+                switch (e.key) {
+                    case 'ArrowUp':
+                        // Solo cambia de celda si no se está editando en una posición específica
+                        newIndex = index - columns >= 0 ? index - columns : index;
+                        break;
+                    case 'ArrowDown':
+                        newIndex = index + columns < inputs.length ? index + columns : index;
+                        break;
+                    case 'ArrowLeft':
+                        // Permite moverse entre caracteres si no está al inicio del campo
+                        if (cursorPos === 0) {
+                            newIndex = index - 1 >= 0 ? index - 1 : index;
+                        }
+                        break;
+                    case 'ArrowRight':
+                        // Permite moverse entre caracteres si no está al final del campo
+                        if (cursorPos === valueLength) {
+                            newIndex = index + 1 < inputs.length ? index + 1 : index;
+                        }
+                        break;
+                    default:
+                        return; // Ignora si no es una tecla de flecha
+                }
+
+                if (newIndex !== index) {
+                    e.preventDefault(); // Evita el movimiento de cursor dentro del campo
+                    inputs[newIndex].focus(); // Mueve el foco a la nueva posición de celda
+                }
+            }
+        });
+    });
     </script>
 </head>
 
@@ -296,62 +352,107 @@ $facultad = $db->query($fac);
                 <?php echo $options_materias; ?>
                 </select>
             </div>
+
+            <!-- Sección de parciales y ordinarios -->
+            <div class="section">
+                <label for="parcial">Parciales:</label>
+                <select name="parcial" id="parcial">
+					<option value="">Seleccione un parcial u ordinario</option>
+                    <option value="parcial1"> Parcial 1</option>
+                    <option value="parcial2"> Parcial 2</option>
+                    <option value="parcial3"> Parcial 3</option>
+                    <option value="Ordinario"> Ordinario</option>
+                    <option value="Ordinario2"> Ordinario 2</option>
+               
+                </select>
+            </div>
             
             <button type="submit" name="buscar">Buscar</button>
         </form>
 
         <?php
-        if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['buscar'])) {
-            if (count($calificaciones) > 0): ?>
-                <form method="post">
-                    <table class="grades-table">
-                        <thead>
-                            <tr>
-                                <th>No.</th>
-                                <th>Matrícula</th>
-                                <th>Alumno</th>
-                                <th>Parcial 1</th>
-                                <th>Parcial 2</th>
-                                <th>Parcial 3</th>
-                                <th>Promedio</th>
-                                <th>Ordinario</th>
-                                <th>Ordinario 2</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <?php 
-                            $valoresCiclo = [];
-                            for ($i = 0; $i < count($calificaciones); $i++): 
-                                $valoresCiclo[] = [
-                                    'indice' => $i + 1,
-                                    'matricula' => $calificaciones[$i]['matricula'],
-                                    'nombre_completo' => $calificaciones[$i]['nombre_completo'],
-                                    'materia_nombre' => $calificaciones[$i]['materia_nombre'],
-                                    'alumno_id' => $calificaciones[$i]['alumno_id'],
-                                    'materia_id' => $calificaciones[$i]['materia_id'],
-                                    'nombre_docente' => $calificaciones[$i]['nombre_docente']
-                                ];
+if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['buscar'])) {
+    // Obtiene la opción seleccionada
+    $parcialSeleccionado = isset($_POST['parcial']) ? $_POST['parcial'] : '';
+
+    if (count($calificaciones) > 0 && !empty($parcialSeleccionado)): ?>
+        <form method="post">
+            <table class="grades-table">
+                <thead>
+                    <tr>
+                        <th>No.</th>
+                        <th>Matrícula</th>
+                        <th>Alumno</th>
+                        <?php
+                        // Mostrar el encabezado solo para la columna seleccionada
+                        switch ($parcialSeleccionado) {
+                            case 'parcial1':
+                                echo "<th>Parcial 1</th>";
+                                break;
+                            case 'parcial2':
+                                echo "<th>Parcial 2</th>";
+                                break;
+                            case 'parcial3':
+                                echo "<th>Parcial 3</th>";
+                                break;
+                            case 'ordinario1':
+                                echo "<th>Ordinario</th>";
+                                break;
+                            case 'ordinario2':
+                                echo "<th>Ordinario 2</th>";
+                                break;
+                        }
+                        ?>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php 
+                    $valoresCiclo = [];
+                    for ($i = 0; $i < count($calificaciones); $i++): 
+                        $valoresCiclo[] = [
+                            'indice' => $i + 1,
+                            'matricula' => $calificaciones[$i]['matricula'],
+                            'nombre_completo' => $calificaciones[$i]['nombre_completo'],
+                            'materia_nombre' => $calificaciones[$i]['materia_nombre'],
+                            'alumno_id' => $calificaciones[$i]['alumno_id'],
+                            'materia_id' => $calificaciones[$i]['materia_id'],
+                            'nombre_docente' => $calificaciones[$i]['nombre_docente']
+                        ];
+                    ?>
+                        <tr>
+                            <td><?php echo $i + 1; ?></td>
+                            <td><?php echo htmlspecialchars($calificaciones[$i]['matricula']); ?></td>
+                            <td><?php echo htmlspecialchars($calificaciones[$i]['nombre_completo']); ?></td>
+                            <?php
+                            // Mostrar solo la columna de calificación seleccionada
+                            switch ($parcialSeleccionado) {
+                                case 'parcial1':
+                                    echo "<td><input type='text' name='parcial_1_{$calificaciones[$i]['alumno_id']}' value='0' tabindex='1' /></td>";
+                                    break;
+                                case 'parcial2':
+                                    echo "<td><input type='text' name='parcial_2_{$calificaciones[$i]['alumno_id']}' value='0' tabindex='1' /></td>";
+                                    break;
+                                case 'parcial3':
+                                    echo "<td><input type='text' name='parcial_3_{$calificaciones[$i]['alumno_id']}' value='0' tabindex='1' /></td>";
+                                    break;
+                                case 'ordinario1':
+                                    echo "<td><input type='text' name='ordinario_1_{$calificaciones[$i]['alumno_id']}' value='0' tabindex='1' /></td>";
+                                    break;
+                                case 'ordinario2':
+                                    echo "<td><input type='text' name='ordinario_2_{$calificaciones[$i]['alumno_id']}' value='0' tabindex='1' /></td>";
+                                    break;
+                            }
                             ?>
-                                <tr>
-                                    <td><?php echo $i + 1; ?></td>
-                                    <td><?php echo htmlspecialchars($calificaciones[$i]['matricula']); ?></td>
-                                    <td><?php echo htmlspecialchars($calificaciones[$i]['nombre_completo']); ?></td>
-                                    <td><input type="text" name="parcial_1_<?php echo htmlspecialchars($calificaciones[$i]['alumno_id']); ?>" value="0" /></td>
-                                    <td><input type="text" name="parcial_2_<?php echo htmlspecialchars($calificaciones[$i]['alumno_id']); ?>" value="0" /></td>
-                                    <td><input type="text" name="parcial_3_<?php echo htmlspecialchars($calificaciones[$i]['alumno_id']); ?>" value="0" /></td>
-                                    <td><input type="text" name="promedio_<?php echo htmlspecialchars($calificaciones[$i]['alumno_id']); ?>" value="0" readonly /></td>
-                                    <td><input type="text" name="ordinario_1_<?php echo htmlspecialchars($calificaciones[$i]['alumno_id']); ?>" value="0" /></td>
-                                    <td><input type="text" name="ordinario_2_<?php echo htmlspecialchars($calificaciones[$i]['alumno_id']); ?>" value="0" /></td>
-                                </tr>
-                            <?php endfor; ?>
-                        </tbody>
-                    </table>
-                    <input type="hidden" name="valores_ciclo" value='<?php echo htmlspecialchars(json_encode($valoresCiclo)); ?>'>
-                    <button type="submit" name="registrar">Registrar</button>
-                </form>
-            <?php else: ?>
-                <p>No hay datos disponibles para la selección actual.</p>
-            <?php endif;
+                        </tr>
+                    <?php endfor; ?>
+                </tbody>
+            </table>
+            <input type="hidden" name="valores_ciclo" value='<?php echo htmlspecialchars(json_encode($valoresCiclo)); ?>'>
+            <button type="submit" name="registrar">Registrar</button>
+        </form>
+    <?php else: ?>
+        <p>No hay datos disponibles para la selección actual.</p>
+    <?php endif;
         }
 
         if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['registrar'])) {


### PR DESCRIPTION
Se agregó otra lista de opciones en la página captura_cal.php para poder elegir el parcial donde se capturará la calificación:

- [ ] Elegir un parcial para capturar calificaciones.
- [ ] La tabla muestre únicamente el parcial seleccionado.
- [ ] La tabla debe estar centrada y con un tamaño reducido, es decir, más estrecho a la tabla del parche anterior.
- [ ] El registro de las calificaciones debe aparecer en la base de datos. El código para que se actualicen los registros en lugar de 
añadir nuevos se modificará en actualizaciones posteriores. 