### PR TITLE
Eliminación de cero en el cuadro de texto

### DIFF
--- a/reportes/captura_cal.php
+++ b/reportes/captura_cal.php
@@ -519,6 +519,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['buscar'])) {
                         }
 
                         $disabled = $calificacionParcial > 0 ? "disabled" : ""; // Desactiva si el valor es mayor a 0
+                        if($calificacionParcial == 0){
+                            $calificacionParcial = null;
+                        }
                     ?>
                         <tr>
                             <td><?php echo $i + 1; ?></td>


### PR DESCRIPTION
Se eliminó el cero en el cuadro de texto en la captura de calificaciones para hacer la inserción de calificaciones más rápida y cómoda