### PR TITLE
Parche 2.101 notificación de registro de asistencia

### DIFF
--- a/send_email.php
+++ b/send_email.php
@@ -109,9 +109,6 @@ if (isset($_GET['email']) && isset($_GET['parcial'])){
     }
 
 
-}else {
-    // Si el token o el resultado no se recibieron por GET, muestra un mensaje de error
-    echo "Error: No se proporcionaron suficientes parámetros en la URL.";
 }
 ?>
 


### PR DESCRIPTION
Se elimina una parte del código que hacia que entrara en conflicto las notificaciones de registro de asistencia con captura de calificaciones